### PR TITLE
add a decorator to mark a function as a Servable

### DIFF
--- a/launch/model_endpoint.py
+++ b/launch/model_endpoint.py
@@ -171,7 +171,7 @@ class AsyncEndpoint(Endpoint):
             return_pickled=request.return_pickled,
         )
         return EndpointResponseFuture(
-            client=self.client, async_task_id=raw_response["task_id"]
+            client=self.client, async_task_id=raw_response
         )
 
     def predict_batch(

--- a/launch/servable.py
+++ b/launch/servable.py
@@ -1,7 +1,7 @@
 from launch.logger import logger
 
 
-def default_make_request(_, fn, *args, **kwargs):
+def default_make_request(_, fn, args, kwargs):
     return fn(*args, **kwargs)
 
 
@@ -27,3 +27,16 @@ def step_decorator(fn):
         return make_request(fn_name, fn, args, kwargs)
 
     return modified_fn
+
+
+def step_decorator_class(class_obj):
+    """
+    Decorator to mark a class as a separate Servable. The class must implement __call__.
+    """
+    old_call = class_obj.__call__
+
+    def modified_call(*args, **kwargs):
+        return make_request(class_obj.__name__, old_call, args, kwargs)
+
+    class_obj.__call__ = modified_call
+    return class_obj

--- a/launch/servable.py
+++ b/launch/servable.py
@@ -24,6 +24,6 @@ def step_decorator(fn):
     fn_name = fn.__name__
 
     def modified_fn(*args, **kwargs):
-        return make_request(fn_name, fn, *args, **kwargs)
+        return make_request(fn_name, fn, args, kwargs)
 
     return modified_fn

--- a/launch/servable.py
+++ b/launch/servable.py
@@ -1,0 +1,29 @@
+from launch.logger import logger
+
+
+def default_make_request(_, fn, *args, **kwargs):
+    return fn(*args, **kwargs)
+
+
+try:
+    # Keep in line with Scale Launch serverside code!
+    from hosted_model_inference.inference.service_requests import make_request
+except ImportError:
+    logger.info(
+        "Unable to import serverside request maker; falling back to local request"
+    )
+    make_request = default_make_request
+
+
+def step_decorator(fn):
+    """
+    Decorator to mark a function as a separate Servable.
+    """
+
+    # Identifiers will just be the name of the function. Must be unique. TODO enforce this uniqueness
+    fn_name = fn.__name__
+
+    def modified_fn(*args, **kwargs):
+        return make_request(fn_name, fn, *args, **kwargs)
+
+    return modified_fn

--- a/launch/servable.py
+++ b/launch/servable.py
@@ -32,6 +32,9 @@ def step_decorator(fn):
 def step_decorator_class(class_obj):
     """
     Decorator to mark a class as a separate Servable. The class must implement __call__.
+    The object used for calling gets instantiated upstream and passed to the child Servable.
+    TODO do we want to have the upstream servable instantiate the object?
+    Also TODO do we want to have a decorator on a class, or a superclass to inherit from?
     """
     old_call = class_obj.__call__
 


### PR DESCRIPTION
upd: this is deprecated, we're not doing decorators

Intended usage:

User does
```
@step_decorator
def some_stage(input1, input2):
    ...

...

def orchestrator(input1):
    result = some_stage(input1, 1)
```
or
```
@step_decorator_class
class SomeClass:
    ...
    def __call__(self, input2):
        ...

def orchestrator(input2):
    class_thing = SomeClass(something)
    res = class_thing(input2)
```
in their code to be run by us, and we turn `some_stage` into a function that can either make a network request, or run code locally. Note: the decorator does not need to be attached to the root stage, so users who want single-stage pipelines, or using legacy bundles, can still use the bundles.