### PR TITLE
Batch inference uses bundles, not endpoints (and also functions)

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -798,9 +798,9 @@ class LaunchClient:
                 file_location = self.bundle_location_fn()  # type: ignore
             else:
                 file_location = batch_url_file_location
-            self.upload_batch_csv_fn(
+            self.upload_batch_csv_fn(  # type: ignore
                 f.getvalue(), file_location
-            )  # type: ignore
+            )
         else:
             # TODO make this not use MODEL_BUNDLE_SIGNED_URL_PATH
             model_bundle_s3_url = self.connection.post(

--- a/launch/client.py
+++ b/launch/client.py
@@ -14,6 +14,7 @@ from launch.connection import Connection
 from launch.constants import (
     ASYNC_TASK_PATH,
     ASYNC_TASK_RESULT_PATH,
+    BATCH_TASK_INPUT_SIGNED_URL_PATH,
     BATCH_TASK_PATH,
     BATCH_TASK_RESULTS_PATH,
     ENDPOINT_PATH,
@@ -386,7 +387,7 @@ class LaunchClient:
         else:
             # Grab a signed url to make upload to
             model_bundle_s3_url = self.connection.post(
-                {}, MODEL_BUNDLE_SIGNED_URL_PATH
+                {}, BATCH_TASK_INPUT_SIGNED_URL_PATH
             )
             s3_path = model_bundle_s3_url["signedUrl"]
             raw_bundle_url = f"s3://{model_bundle_s3_url['bucket']}/{model_bundle_s3_url['key']}"

--- a/launch/client.py
+++ b/launch/client.py
@@ -387,7 +387,7 @@ class LaunchClient:
         else:
             # Grab a signed url to make upload to
             model_bundle_s3_url = self.connection.post(
-                {}, BATCH_TASK_INPUT_SIGNED_URL_PATH
+                {}, MODEL_BUNDLE_SIGNED_URL_PATH
             )
             s3_path = model_bundle_s3_url["signedUrl"]
             raw_bundle_url = f"s3://{model_bundle_s3_url['bucket']}/{model_bundle_s3_url['key']}"
@@ -803,9 +803,8 @@ class LaunchClient:
                 f.getvalue(), file_location
             )
         else:
-            # TODO make this not use MODEL_BUNDLE_SIGNED_URL_PATH
             model_bundle_s3_url = self.connection.post(
-                {}, MODEL_BUNDLE_SIGNED_URL_PATH
+                {}, BATCH_TASK_INPUT_SIGNED_URL_PATH
             )
             s3_path = model_bundle_s3_url["signedUrl"]
             requests.put(s3_path, data=f.getvalue())

--- a/launch/client.py
+++ b/launch/client.py
@@ -768,8 +768,8 @@ class LaunchClient:
     def batch_async_request(
         self,
         bundle_name: str,
-        # urls_file: str,
         urls: List[str],
+        batch_url_file_location: str = None,
         serialization_format: str = "json",
     ):
         """
@@ -780,9 +780,10 @@ class LaunchClient:
             bundle_name: The id of the bundle to make the request to
             serialization_format: Serialization format of output, either 'pickle' or 'json'.
                 'pickle' corresponds to pickling results + returning
-            urls_file: S3 location of a CSV that is used as input to the batch job. TODO this really should be a list of urls
             urls: A list of urls, each pointing to a file containing model input.
                 Must be accessible by Scale Launch, hence urls need to either be public or signedURLs.
+            batch_url_file_location: In self-hosted mode, the input to the batch job will be uploaded
+                to this location if provided. Otherwise, one will be determined from bundle_location_fn()
 
         Returns:
             An id/key that can be used to fetch inference results at a later time
@@ -793,7 +794,10 @@ class LaunchClient:
 
         if self.self_hosted:
             # TODO make this not use bundle_location_fn()
-            file_location = self.bundle_location_fn()  # type: ignore
+            if batch_url_file_location is None:
+                file_location = self.bundle_location_fn()  # type: ignore
+            else:
+                file_location = batch_url_file_location
             self.upload_batch_csv_fn(
                 f.getvalue(), file_location
             )  # type: ignore

--- a/launch/client.py
+++ b/launch/client.py
@@ -802,6 +802,7 @@ class LaunchClient:
                 f.getvalue(), file_location
             )  # type: ignore
         else:
+            # TODO make this not use MODEL_BUNDLE_SIGNED_URL_PATH
             model_bundle_s3_url = self.connection.post(
                 {}, MODEL_BUNDLE_SIGNED_URL_PATH
             )

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -3,6 +3,8 @@ MODEL_BUNDLE_SIGNED_URL_PATH = "model_bundle_upload"
 ASYNC_TASK_PATH = "task_async"
 ASYNC_TASK_RESULT_PATH = "task/result"
 SYNC_TASK_PATH = "task_sync"
+BATCH_TASK_PATH = "batch_task_async"
+BATCH_TASK_RESULTS_PATH = "batch_task_async_result"
 SCALE_LAUNCH_ENDPOINT = "https://api.scale.com/v1/hosted_inference"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -1,5 +1,6 @@
 ENDPOINT_PATH = "endpoints"
 MODEL_BUNDLE_SIGNED_URL_PATH = "model_bundle_upload"
+BATCH_TASK_INPUT_SIGNED_URL_PATH = "batch_task_input_upload"
 ASYNC_TASK_PATH = "task_async"
 ASYNC_TASK_RESULT_PATH = "task/result"
 SYNC_TASK_PATH = "task_sync"

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -3,8 +3,8 @@ MODEL_BUNDLE_SIGNED_URL_PATH = "model_bundle_upload"
 ASYNC_TASK_PATH = "task_async"
 ASYNC_TASK_RESULT_PATH = "task/result"
 SYNC_TASK_PATH = "task_sync"
-BATCH_TASK_PATH = "batch_task_async"
-BATCH_TASK_RESULTS_PATH = "batch_task_async/result"
+BATCH_TASK_PATH = "batch_job"
+BATCH_TASK_RESULTS_PATH = "batch_job"
 SCALE_LAUNCH_ENDPOINT = "https://api.scale.com/v1/hosted_inference"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -4,7 +4,7 @@ ASYNC_TASK_PATH = "task_async"
 ASYNC_TASK_RESULT_PATH = "task/result"
 SYNC_TASK_PATH = "task_sync"
 BATCH_TASK_PATH = "batch_task_async"
-BATCH_TASK_RESULTS_PATH = "batch_task_async_result"
+BATCH_TASK_RESULTS_PATH = "batch_task_async/result"
 SCALE_LAUNCH_ENDPOINT = "https://api.scale.com/v1/hosted_inference"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120

--- a/launch/make_batch_file.py
+++ b/launch/make_batch_file.py
@@ -1,0 +1,9 @@
+import csv
+from typing import IO, List
+
+
+def make_batch_input_file(urls: List[str], file: IO[str]):
+    writer = csv.DictWriter(file, fieldnames=["id", "url"])
+    writer.writeheader()
+    for i, url in enumerate(urls):
+        writer.writerow({"id": i, "url": url})

--- a/tests/test_make_batch_file.py
+++ b/tests/test_make_batch_file.py
@@ -1,18 +1,21 @@
 import csv
-import tempfile
+from io import StringIO
 
 from launch.make_batch_file import make_batch_input_file
 
 
 def test_make_batch_file():
-    with tempfile.NamedTemporaryFile("w") as f:
-        urls = ["one_url.count", "two_urls.count", "three_urls.count"]
-        make_batch_input_file(urls, f)
+    f = StringIO()
+    urls = ["one_url.count", "two_urls.count", "three_urls.count"]
+    make_batch_input_file(urls, f)
+    f.seek(0)
 
-        with open(f.name, "r") as f_read:
-            reader = csv.DictReader(f_read)
-            rows = [row for row in reader]
-            print(rows)
-            for i, expected_row, actual_row in zip(*enumerate(urls), rows):
-                assert i == actual_row["id"]
-                assert expected_row == actual_row["url"]
+    reader = csv.DictReader(f)
+    rows = [row for row in reader]
+    print(f.getvalue())
+    print(rows)
+    for tup in zip(enumerate(urls), rows):
+        print(tup)
+        (i, expected_row), actual_row = tup
+        assert str(i) == actual_row["id"]
+        assert expected_row == actual_row["url"]

--- a/tests/test_make_batch_file.py
+++ b/tests/test_make_batch_file.py
@@ -1,0 +1,18 @@
+import csv
+import tempfile
+
+from launch.make_batch_file import make_batch_input_file
+
+
+def test_make_batch_file():
+    with tempfile.NamedTemporaryFile("w") as f:
+        urls = ["one_url.count", "two_urls.count", "three_urls.count"]
+        make_batch_input_file(urls, f)
+
+        with open(f.name, "r") as f_read:
+            reader = csv.DictReader(f_read)
+            rows = [row for row in reader]
+            print(rows)
+            for i, expected_row, actual_row in zip(*enumerate(urls), rows):
+                assert i == actual_row["id"]
+                assert expected_row == actual_row["url"]


### PR DESCRIPTION
Current API is that users pass in a list of urls to the client function, which uploads the csv for them. 

Specifically, the client api to `batch_async_request` is `bundle_name`, `urls`, `batch_url_file_location`, and `serialization_format`, where `urls` is a list of urls that get put in the csv. Talking to Chongz, it sounds like something else that could work (for typescript + python clients) is to have `urls` be a map `{user_set_id: url}`, since right now, we just use numeric ids.

Note about uploading the csv: The text is kept in memory so a gigantic (like many millions of tasks) batch of tasks might cause an OOM, but `urls` is stored in memory anyways.

Further improvements: possibly allow users to pass in a map `{id: url}`, or even further pass in `args` instead of`url`.

Testing: sent a batch inference request to `hostedinference-sean` on training and it worked

See https://app.shortcut.com/scaleai/story/367907/a-user-can-submit-a-batch-inference-job