### PR TITLE
Support deploying pipelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
     hooks:
     - id: system
       name: mypy
-      entry: poetry run mypy --ignore-missing-imports launch
+      entry: poetry run mypy --ignore-missing-imports launch --exclude launch/clientlib
       pass_filenames: false
       language: system

--- a/launch/client.py
+++ b/launch/client.py
@@ -9,6 +9,7 @@ import cloudpickle
 import requests
 import yaml
 
+import launch
 from launch.connection import Connection
 from launch.constants import (
     ASYNC_TASK_PATH,
@@ -26,6 +27,12 @@ from launch.model_endpoint import (
     Endpoint,
     ModelEndpoint,
     SyncEndpoint,
+)
+from launch.pipeline import (
+    Deployment,
+    Runtime,
+    ServiceDescription,
+    find_all_sub_service_descriptions,
 )
 from launch.request_validation import validate_task_request
 from launch.utils import trim_kwargs
@@ -312,6 +319,7 @@ class LaunchClient:
                 model_bundle_name,
             )
 
+        cloudpickle.register_pickle_by_value(launch)  # register launch API
         # Prepare cloudpickle for external imports
         if globals_copy:
             for module in get_imports(globals_copy):
@@ -406,6 +414,7 @@ class LaunchClient:
         gpu_type: Optional[str] = None,
         endpoint_type: str = "sync",
         update_if_exists: bool = False,
+        child_fn_info: Optional[Dict[str, Any]] = None,
     ) -> Optional[Endpoint]:
         """
         Creates a Model Endpoint that is able to serve requests.
@@ -461,6 +470,7 @@ class LaunchClient:
                 max_workers=max_workers,
                 per_worker=per_worker,
                 endpoint_type=endpoint_type,
+                child_fn_info=child_fn_info,
             )
             if gpus == 0:
                 del payload["gpu_type"]
@@ -485,6 +495,86 @@ class LaunchClient:
                 raise ValueError(
                     "Endpoint should be one of the types 'sync' or 'async'"
                 )
+
+    def deploy_service(
+        self,
+        model_bundle_name: str,
+        endpoint_name: str,
+        service_description: ServiceDescription,
+        bundle_url_prefix: Optional[str] = None,
+        globals_copy: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Endpoint]:
+        """
+        Deploy a service represented by a Service Description object such as a Step or a Pipeline.
+
+        Parameters:
+            model_bundle_name: Name of model bundle you want to create. This acts as a unique identifier.
+            endpoint_name: Name of model endpoint. Must be unique.
+            service_description: A step or a Pipeline.
+            bundle_url_prefix: Only for self-hosted mode. Desired location of bundle.
+            globals_copy: Dictionary of the global symbol table. Normally provided by `globals()` built-in function.
+
+        Returns:
+             A Endpoint object that can be used to make requests to the endpoint.
+
+        """
+        sub_service_descriptions = find_all_sub_service_descriptions(
+            service_description
+        )
+        # Fill `child_fn_info` needed for service discovery
+        child_fn_info = {}
+        for sub_service_description in sub_service_descriptions:
+            # If this is the root service target.
+            if (
+                service_description.service_name
+                == sub_service_description.service_name
+            ):
+                sub_service_description.service_name = model_bundle_name
+
+            child_fn_info[sub_service_description.service_name] = dict(
+                remote=True,
+                endpoint_type=sub_service_description.runtime.name.lower(),
+                destination="undefined",
+            )
+
+        res_endpoint = None
+        for sub_service_description in sub_service_descriptions:
+            service_name = sub_service_description.service_name
+
+            if bundle_url_prefix:
+                bundle_url = f"{bundle_url_prefix}/{service_name}.pkl"
+            else:
+                bundle_url = None
+
+            model_bundle = self.create_model_bundle(
+                service_name,
+                predict_fn_or_cls=sub_service_description,
+                bundle_url=bundle_url,
+                env_params=sub_service_description.deployment.env_params,
+                globals_copy=globals_copy,
+            )
+
+            logger.info(f"Bundle {service_name} created")
+
+            endpoint = self.create_model_endpoint(
+                endpoint_name=service_name,
+                model_bundle=model_bundle,
+                cpus=service_description.deployment.cpu,
+                memory=service_description.deployment.memory,
+                gpus=service_description.deployment.gpu,
+                min_workers=service_description.deployment.min_workers,
+                max_workers=service_description.deployment.max_workers,
+                per_worker=service_description.deployment.per_worker,
+                gpu_type=service_description.deployment.gpu_type,
+                endpoint_type=service_description.runtime.name.lower(),
+                update_if_exists=False,
+                child_fn_info=child_fn_info,
+            )
+            logger.info(f"Endpoint {service_name} created")
+
+            if (service_description.service_name == sub_service_description.service_name):
+                res_endpoint = endpoint
+        return res_endpoint
 
     def edit_model_endpoint(
         self,

--- a/launch/client.py
+++ b/launch/client.py
@@ -11,7 +11,7 @@ import cloudpickle
 import requests
 import yaml
 
-import launch
+import launch  # pylint: disable=R0401
 from launch.connection import Connection
 from launch.constants import (
     ASYNC_TASK_PATH,

--- a/launch/pipeline/__init__.py
+++ b/launch/pipeline/__init__.py
@@ -1,11 +1,12 @@
 from launch.pipeline.deployment import Deployment
 from launch.pipeline.runtime import Runtime
 from launch.pipeline.service import (
-    ServiceDescription,
     SequentialPipelineDescription,
+    ServiceDescription,
     SingleServiceDescription,
 )
 from launch.pipeline.utils import (
+    deploy_service,
     find_all_sub_service_descriptions,
     make_sequential_pipeline,
     make_service,

--- a/launch/pipeline/__init__.py
+++ b/launch/pipeline/__init__.py
@@ -1,7 +1,12 @@
 from launch.pipeline.deployment import Deployment
 from launch.pipeline.runtime import Runtime
 from launch.pipeline.service import (
+    ServiceDescription,
     SequentialPipelineDescription,
     SingleServiceDescription,
 )
-from launch.pipeline.utils import make_sequential_pipeline, make_service
+from launch.pipeline.utils import (
+    find_all_sub_service_descriptions,
+    make_sequential_pipeline,
+    make_service,
+)

--- a/launch/pipeline/deployment.py
+++ b/launch/pipeline/deployment.py
@@ -1,6 +1,15 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class Deployment:
     """Base deployment class"""
+
+    cpus: int = 1
+    gpus: int = 0
+    gpu_type: Optional[str] = None
+    memory: str = "4Gi"
+    min_workers: int = 0
+    max_workers: int = 1
+    per_worker: int = 1

--- a/launch/pipeline/service.py
+++ b/launch/pipeline/service.py
@@ -14,6 +14,10 @@ class ServiceDescription:
     """
 
     service_name: str
+    service: Callable
+    runtime: Runtime
+    deployment: Deployment
+    env_params: Dict[str, str]
 
     def __init__(self):
         self.make_request: Optional[Callable] = None
@@ -40,12 +44,14 @@ class SingleServiceDescription(ServiceDescription):
         service: Callable,
         runtime: Runtime,
         deployment: Deployment,
+        env_params: Dict[str, str],
         **kwargs: Dict[str, Any],
     ):
         super().__init__()
-        self.service = service
+        setattr(self, "service", service)
         self.runtime = runtime
         self.deployment = deployment
+        self.env_params = env_params
         self.kwargs = kwargs
         func_name = service.__name__.replace("_", "").replace("-", "")
         self.service_name = f"{func_name}{uuid.uuid4()}"[
@@ -97,11 +103,16 @@ class SequentialPipelineDescription(ServiceDescription):
         items: List[SingleServiceDescription],
         runtime: Runtime,
         deployment: Deployment,
+        env_params: Dict[str, str],
     ):
         super().__init__()
+        setattr(
+            self, "service", self
+        )  # Pipeline is itself a service via the __call__ function
         self.items = items
         self.runtime = runtime
         self.deployment = deployment
+        self.env_params = env_params
         self.service_name = f"pipeline{uuid.uuid4()}"[:MAX_SERVICE_NAME_SIZE]
 
     def set_make_request(

--- a/launch/pipeline/utils.py
+++ b/launch/pipeline/utils.py
@@ -5,7 +5,23 @@ from launch.pipeline.runtime import Runtime
 from launch.pipeline.service import (
     SequentialPipelineDescription,
     SingleServiceDescription,
+    ServiceDescription,
 )
+
+
+def find_all_sub_service_descriptions(
+    target_service: ServiceDescription,
+) -> List[ServiceDescription]:
+    """
+    Find all the services involved in the pipeline.
+    """
+    service_descriptions = [target_service]
+    if isinstance(target_service, SequentialPipelineDescription):
+        for sub_service_description in target_service.items:
+            service_descriptions.extend(
+                find_all_sub_service_descriptions(sub_service_description)
+            )
+    return service_descriptions
 
 
 def make_service(
@@ -27,8 +43,14 @@ def make_service(
 
 def make_sequential_pipeline(
     items: List[SingleServiceDescription],
+    runtime: Runtime,
+    deployment: Deployment,
 ) -> SequentialPipelineDescription:
     """
     Create a structure that describes a sequential pipeline.
     """
-    return SequentialPipelineDescription(items=items)
+    return SequentialPipelineDescription(
+        items=items,
+        runtime=runtime,
+        deployment=deployment,
+    )

--- a/launch/pipeline/utils.py
+++ b/launch/pipeline/utils.py
@@ -1,12 +1,17 @@
-from typing import Any, Callable, Dict, List
+import logging
+from typing import Any, Callable, Dict, List, Optional
 
+from launch.model_endpoint import Endpoint
 from launch.pipeline.deployment import Deployment
 from launch.pipeline.runtime import Runtime
 from launch.pipeline.service import (
     SequentialPipelineDescription,
-    SingleServiceDescription,
     ServiceDescription,
+    SingleServiceDescription,
 )
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
 
 
 def find_all_sub_service_descriptions(
@@ -28,6 +33,7 @@ def make_service(
     service: Callable,
     runtime: Runtime,
     deployment: Deployment,
+    env_params: Dict[str, str],
     **kwargs: Dict[str, Any],
 ) -> SingleServiceDescription:
     """
@@ -37,6 +43,7 @@ def make_service(
         service=service,
         runtime=runtime,
         deployment=deployment,
+        env_params=env_params,
         **kwargs,
     )
 
@@ -45,6 +52,7 @@ def make_sequential_pipeline(
     items: List[SingleServiceDescription],
     runtime: Runtime,
     deployment: Deployment,
+    env_params: Dict[str, str],
 ) -> SequentialPipelineDescription:
     """
     Create a structure that describes a sequential pipeline.
@@ -53,4 +61,90 @@ def make_sequential_pipeline(
         items=items,
         runtime=runtime,
         deployment=deployment,
+        env_params=env_params,
     )
+
+
+def deploy_service(
+    client,
+    model_bundle_name: str,
+    endpoint_name: str,
+    service_description: ServiceDescription,
+    bundle_url_prefix: Optional[str] = None,
+    globals_copy: Optional[Dict[str, Any]] = None,
+) -> Optional[Endpoint]:
+    """
+    Deploy a service represented by a Service Description object such as a Step or a Pipeline.
+
+    Parameters:
+        client: Launch API client.
+        model_bundle_name: Name of model bundle you want to create. This acts as a unique identifier.
+        endpoint_name: Name of model endpoint. Must be unique.
+        service_description: A step or a Pipeline.
+        bundle_url_prefix: Only for self-hosted mode. Desired location of bundle.
+        globals_copy: Dictionary of the global symbol table. Normally provided by `globals()` built-in function.
+
+    Returns:
+         A Endpoint object that can be used to make requests to the endpoint.
+
+    """
+    sub_service_descriptions = find_all_sub_service_descriptions(
+        service_description
+    )
+    # Fill `child_fn_info` needed for service discovery
+    child_fn_info = {}
+    for sub_service_description in sub_service_descriptions:
+        # If this is the root service target.
+        if (
+            service_description.service_name
+            == sub_service_description.service_name
+        ):
+            sub_service_description.service_name = model_bundle_name
+
+        child_fn_info[sub_service_description.service_name] = dict(
+            remote=True,
+            endpoint_type=sub_service_description.runtime.name.lower(),
+            destination="undefined",
+        )
+
+    res_endpoint = None
+    for sub_service_description in sub_service_descriptions:
+        service_name = sub_service_description.service_name
+
+        if bundle_url_prefix:
+            bundle_url = f"{bundle_url_prefix}/{service_name}.pkl"
+        else:
+            bundle_url = None
+
+        model_bundle = client.create_model_bundle(
+            service_name,
+            predict_fn_or_cls=sub_service_description.service,
+            bundle_url=bundle_url,
+            env_params=sub_service_description.env_params,
+            globals_copy=globals_copy,
+        )
+
+        logger.info("Bundle %s created", service_name)
+
+        endpoint = client.create_model_endpoint(
+            endpoint_name=service_name,
+            model_bundle=model_bundle,
+            cpus=service_description.deployment.cpus,
+            memory=service_description.deployment.memory,
+            gpus=service_description.deployment.gpus,
+            min_workers=service_description.deployment.min_workers,
+            max_workers=service_description.deployment.max_workers,
+            per_worker=service_description.deployment.per_worker,
+            gpu_type=service_description.deployment.gpu_type,
+            endpoint_type=service_description.runtime.name.lower(),
+            update_if_exists=False,
+            child_fn_info=child_fn_info,
+        )
+        logger.info("Endpoint %s created", service_name)
+
+        if (
+            service_description.service_name
+            == sub_service_description.service_name
+        ):
+            res_endpoint = endpoint
+    return res_endpoint

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,6 +35,9 @@ class DummyDeployment(Deployment):
     memory: int = 4000
 
 
+DUMMY_ENV_PARAMS = {}
+
+
 def test_pipeline():
     TEST_CASE = "hello,world"
 
@@ -42,12 +45,14 @@ def test_pipeline():
         service=splitter,
         runtime=Runtime.SYNC,
         deployment=DummyDeployment(),
+        env_params=DUMMY_ENV_PARAMS,
     )
 
     step_2 = make_service(
         service=Joiner,
         runtime=Runtime.SYNC,
         deployment=DummyDeployment(),
+        env_params=DUMMY_ENV_PARAMS,
         # kwargs:
         sep="-",
     )
@@ -57,5 +62,10 @@ def test_pipeline():
     assert "hello-world" == step_2.call(step_1.call(TEST_CASE))
 
     # test sequential pipeline
-    replace_pipeline = make_sequential_pipeline([step_1, step_2])
+    replace_pipeline = make_sequential_pipeline(
+        [step_1, step_2],
+        runtime=Runtime.SYNC,
+        deployment=DummyDeployment(),
+        env_params=DUMMY_ENV_PARAMS,
+    )
     assert "hello-world" == replace_pipeline.call("hello,world")


### PR DESCRIPTION
This is one of the options on how to deploy the pipeline. It materializes each step of the pipeline as an independent service. Each step calls each other with a specified by the Runtime method i.e. http/celery

The Main deployment function is `deploy_service` https://github.com/scaleapi/launch-python-client/pull/20/files#diff-3593efb1082ee4ff114b9e27e7f8381723026eff460ec37aa53ccbf71e000f3aR499 . It recursively looks for all of  ServiceDescriptions and deploys them independently: create a bundle and use Runtime and Deployment to create an Endpoint.

`set_make_request` is a hook function used on the backend side. The idea is that users running the pipeline locally don't need to call an external service as a step. Remote `call`, on the other hand, will need to make an internal request to another service. The details of it is unknown for the library user, the call is implemented on the backend side via `make_request` function.

This PR is linked to https://github.com/scaleapi/models/pull/3187