### PR TITLE
Add endpoint name to async get request

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -788,7 +788,9 @@ class LaunchClient:
         )
         return resp
 
-    def get_async_endpoint_response(self, endpoint_name: str, async_task_id: str) -> Dict[str, Any]:
+    def get_async_endpoint_response(
+        self, endpoint_name: str, async_task_id: str
+    ) -> Dict[str, Any]:
         """
         Not recommended to use this, instead we recommend to use functions provided by AsyncEndpoint.
         Gets inference results from a previously created task.

--- a/launch/client.py
+++ b/launch/client.py
@@ -20,7 +20,6 @@ from launch.constants import (
     BATCH_TASK_RESULTS_PATH,
     ENDPOINT_PATH,
     MODEL_BUNDLE_SIGNED_URL_PATH,
-    RESULT_PATH,
     SCALE_LAUNCH_ENDPOINT,
     SYNC_TASK_PATH,
 )
@@ -813,7 +812,7 @@ class LaunchClient:
         """
 
         resp = self.connection.get(
-            route=f"{ASYNC_TASK_PATH}/{endpoint_name}/{RESULT_PATH}/{async_task_id}"
+            route=f"{ENDPOINT_PATH}/{endpoint_name}/{ASYNC_TASK_PATH}/{async_task_id}"
         )
         return resp
 

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -6,6 +6,7 @@ ASYNC_TASK_RESULT_PATH = "task/result"
 SYNC_TASK_PATH = "task_sync"
 BATCH_TASK_PATH = "batch_job"
 BATCH_TASK_RESULTS_PATH = "batch_job"
+RESULT_PATH = "result"
 SCALE_LAUNCH_ENDPOINT = "https://api.scale.com/v1/hosted_inference"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120

--- a/launch/model_endpoint.py
+++ b/launch/model_endpoint.py
@@ -174,7 +174,9 @@ class AsyncEndpoint(Endpoint):
             return_pickled=request.return_pickled,
         )
         return EndpointResponseFuture(
-            client=self.client, endpoint_name=self.model_endpoint.name, async_task_id=async_task_id
+            client=self.client,
+            endpoint_name=self.model_endpoint.name,
+            async_task_id=async_task_id,
         )
 
         # FIXME: Figure out a way to structure the responses between the client and endpoint

--- a/launch/model_endpoint.py
+++ b/launch/model_endpoint.py
@@ -211,7 +211,7 @@ class AsyncEndpoint(Endpoint):
             # request has keys url and args
 
             inner_inference_request = self.client.async_request(
-                endpoint_id=self.model_endpoint.name,
+                endpoint_name=self.model_endpoint.name,
                 url=request.url,
                 args=request.args,
                 return_pickled=request.return_pickled,


### PR DESCRIPTION
# Pull Request Summary
Uses new endpoint introduced in https://github.com/scaleapi/models/pull/3204 to get async result with the endpoint name in the URL. This enables future validation that the tasks actually belong to that endpoint, which enables user authorization checks.

Follow-up PR to delete old route to come.

# Clubhouse Ticket
[[ch418719]](https://app.clubhouse.io/scaleai/story/418719)