### PR TITLE
Add configs to model info

### DIFF
--- a/launch/model_endpoint.py
+++ b/launch/model_endpoint.py
@@ -29,6 +29,7 @@ class ModelEndpoint:
     worker_settings: Optional[dict] = None
     metadata: Optional[dict] = None
     endpoint_type: Optional[str] = None
+    configs: Optional[dict] = None
 
     def __repr__(self):
         return f"ModelEndpoint(name='{self.name}', bundle_name='{self.bundle_name}', status='{self.status}', resource_settings='{json.dumps(self.resource_settings)}', worker_settings='{json.dumps(self.worker_settings)}', endpoint_type='{self.endpoint_type}', metadata='{self.metadata}')"


### PR DESCRIPTION
Follow-up to https://github.com/scaleapi/models/pull/3279#issuecomment-1144200669

[[sc-475260]](https://app.shortcut.com/scaleai/story/475260/return-post-inference-hooks-in-get-endpoint-details)