### PR TITLE
Fix inner function wrapping for previously deprecated methods

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -997,8 +997,10 @@ class LaunchClient:
         )
         return resp["task_id"]
 
-    @deprecated(details="Use EndpointResponseFuture.get(), where EndpointResponseFuture "
-                        "is returned by AsyncEndpoint.predict()")
+    @deprecated(
+        details="Use EndpointResponseFuture.get(), where EndpointResponseFuture "
+        "is returned by AsyncEndpoint.predict()"
+    )
     def get_async_response(self, async_task_id: str) -> Dict[str, Any]:
         """
         Not recommended to use this, instead we recommend to use functions provided by ``AsyncEndpoint``.

--- a/launch/client.py
+++ b/launch/client.py
@@ -905,7 +905,7 @@ class LaunchClient:
         )
         return resp
 
-    @deprecated
+    @deprecated(details="Use AsyncEndpoint.predict() instead")
     def async_request(
         self,
         endpoint_name: str,
@@ -997,7 +997,8 @@ class LaunchClient:
         )
         return resp["task_id"]
 
-    @deprecated
+    @deprecated(details="Use EndpointResponseFuture.get(), where EndpointResponseFuture "
+                        "is returned by AsyncEndpoint.predict()")
     def get_async_response(self, async_task_id: str) -> Dict[str, Any]:
         """
         Not recommended to use this, instead we recommend to use functions provided by ``AsyncEndpoint``.


### PR DESCRIPTION
In #33 I added `@deprecated`, but that broke the deprecated methods due to improper wrapping:
```
TypeError: _function_wrapper() got an unexpected keyword argument 'args'
```

It turns out that `@deprecated` needs `details`.

Tested with:
```
In [1]: from launch_internal import get_launch_client

In [2]: client = get_launch_client(api_key='yi')

In [3]: client.async_request("asdf")
<ipython-input-3-b93224a43d2e>:1: DeprecatedWarning: async_request is deprecated. Use AsyncEndpoint.predict() instead
  client.async_request("asdf")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-b93224a43d2e> in <module>
----> 1 client.async_request("asdf")

~/.pyenv/versions/3.8.5/lib/python3.8/site-packages/deprecation.py in _inner(*args, **kwargs)
    258                               stacklevel=2)
    259 
--> 260             return function(*args, **kwargs)
    261         return _inner
    262     return _function_wrapper

~/.pyenv/versions/3.8.5/lib/python3.8/site-packages/launch/client.py in async_request(self, endpoint_name, url, args, return_pickled)
    944                 `abcabcab-cabc-abca-0123456789ab`
    945         """
--> 946         return self._async_request(
    947             endpoint_name=endpoint_name,
    948             url=url,

~/.pyenv/versions/3.8.5/lib/python3.8/site-packages/launch/client.py in _async_request(self, endpoint_name, url, args, return_pickled)
    985                 `abcabcab-cabc-abca-0123456789ab`
    986         """
--> 987         validate_task_request(url=url, args=args)
    988         payload: Dict[str, Any] = dict(return_pickled=return_pickled)
    989         if url is not None:

~/.pyenv/versions/3.8.5/lib/python3.8/site-packages/launch/request_validation.py in validate_task_request(url, args)
     12     # A task request must have at least one of url or args, otherwise there's no input!
     13     if url is None and args is None:
---> 14         raise ValueError("Must specify at least one of url or args")
     15     if url is not None and args is not None:
     16         logger.warning(

ValueError: Must specify at least one of url or args
```