### PR TITLE
skip logging error when getting an non-existing endpoint

### DIFF
--- a/launch/errors.py
+++ b/launch/errors.py
@@ -15,6 +15,7 @@ class APIError(Exception):
         message = f"Your client is on version {launch_client_version}. If you have not recently done so, please make sure you have updated to the latest version of the client by reinstalling the client.\n"
         if requests_response is not None:
             message += f"Tried to {command.__name__} {endpoint}, but received {requests_response.status_code}: {requests_response.reason}."
+            self.status_code = requests_response.status_code
             if hasattr(requests_response, "text"):
                 if requests_response.text:
                     message += (
@@ -24,6 +25,7 @@ class APIError(Exception):
         if aiohttp_response is not None:
             status, reason, data = aiohttp_response
             message += f"Tried to {command.__name__} {endpoint}, but received {status}: {reason}."
+            self.status_code = status
             if data:
                 message += f"\nThe detailed error is:\n{data}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ furo = "^2022.4.7"
 [tool.poetry.scripts]
 scale-launch = 'launch.cli.bin:entry_point'
 
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,3 +88,14 @@ def test_create_model_bundle_from_dirs_bundle_contents_correct(
         load_model_fn_module_path="a.b.c",
         app_config=None,
     )
+
+
+def test_get_non_existent_model_endpoint(requests_mock):  # noqa: F811
+    client = _get_mock_client()
+    requests_mock.get(
+        "https://api.scale.com/v1/hosted_inference/endpoints/non-existent-endpoint",
+        status_code=404,
+        reason="Not Found",
+    )
+    endpoint = client.get_model_endpoint("non-existent-endpoint")
+    assert endpoint is None


### PR DESCRIPTION
# Pull Request Summary

The previous unnecessary error logs come from `get_model_endpoint` when the endpoint does not exist, so I skip logging error when the `APIError.status_code == 404`. Also reverted the previous implementation as in https://github.com/scaleapi/launch-python-client/pull/31 and closed https://github.com/scaleapi/launch-python-client/pull/34

## Test plan

- I was able to reproduce Felix's error locally. 
- With this change I was able to create a new endpoint with `update_if_exists=True` and no error logs were printed out.

## Clubhouse Ticket
[sc-491834](https://app.shortcut.com/scaleai/story/491834/suppress-error-logs-on-create-model-endpoint-when-update-if-exists-is-set-to-true)