### PR TITLE
add status, resource_settings, worker_settings methods

### DIFF
--- a/launch/model_endpoint.py
+++ b/launch/model_endpoint.py
@@ -222,25 +222,25 @@ class Endpoint:
         self.model_endpoint = model_endpoint
         self.client = client
 
-    def _update_model_endpoint(self):
+    def _update_model_endpoint_view(self):
         resp = self.client.connection.get(
             os.path.join(ENDPOINT_PATH, self.model_endpoint.name)
         )
         self.model_endpoint = ModelEndpoint.from_dict(resp)
 
-    def status(self):
+    def status(self) -> Optional[str]:
         """Gets the status of the Endpoint."""
-        self._update_model_endpoint()
+        self._update_model_endpoint_view()
         return self.model_endpoint.status
 
-    def resource_settings(self):
+    def resource_settings(self) -> Optional[dict]:
         """Gets the resource settings of the Endpoint."""
-        self._update_model_endpoint()
+        self._update_model_endpoint_view()
         return self.model_endpoint.resource_settings
 
-    def worker_settings(self):
+    def worker_settings(self) -> Optional[dict]:
         """Gets the worker settings of the Endpoint."""
-        self._update_model_endpoint()
+        self._update_model_endpoint_view()
         return self.model_endpoint.worker_settings
 
 

--- a/tests/test_model_endpoint.py
+++ b/tests/test_model_endpoint.py
@@ -1,0 +1,61 @@
+import json
+
+import requests
+import requests_mock
+
+import launch
+
+
+def _get_mock_client():
+    client = launch.LaunchClient(api_key="test")
+    return client
+
+
+def test_status_returns_updated_value(requests_mock):  # noqa: F811
+    client = _get_mock_client()
+
+    json_str = """{
+        "bundle_name": "test-returns-1",
+        "configs": {
+            "app_config": null,
+            "endpoint_config": {
+                "bundle_name": "test-returns-1",
+                "endpoint_name": "test-endpoint",
+                "post_inference_hooks": null
+            }
+        },
+        "destination": "launch.xxx",
+        "endpoint_type": "async",
+        "metadata": null,
+        "name": "test-endpoint",
+        "resource_settings": {
+            "cpus": "2",
+            "gpu_type": null,
+            "gpus": 0,
+            "memory": "4Gi"
+        },
+        "worker_settings": {
+            "available_workers": 1,
+            "max_workers": "1",
+            "min_workers": "1",
+            "per_worker": "1",
+            "unavailable_workers": 0
+        }
+    }"""
+    resp = json.loads(json_str)
+    update_pending_resp = {**resp, "status": "UPDATE_PENDING"}
+    update_in_progress_resp = {**resp, "status": "UPDATE_IN_PROGRESS"}
+    ready_resp = {**resp, "status": "READY"}
+
+    requests_mock.get(
+        "https://api.scale.com/v1/hosted_inference/endpoints/test-endpoint",
+        [
+            {"json": update_pending_resp},
+            {"json": update_in_progress_resp},
+            {"json": ready_resp},
+        ],
+    )
+
+    endpoint = client.get_model_endpoint("test-endpoint")
+    assert endpoint.status() == "UPDATE_IN_PROGRESS"
+    assert endpoint.status() == "READY"

--- a/tests/test_model_endpoint.py
+++ b/tests/test_model_endpoint.py
@@ -56,6 +56,6 @@ def test_status_returns_updated_value(requests_mock):  # noqa: F811
         ],
     )
 
-    endpoint = client.get_model_endpoint("test-endpoint")
+    endpoint = client.get_model_endpoint("test-endpoint")  # UPDATE_PENDING
     assert endpoint.status() == "UPDATE_IN_PROGRESS"
     assert endpoint.status() == "READY"


### PR DESCRIPTION
# Pull Request Summary

- update the endpoint status by making an API call first
- the same issue also applies to all endpoint settings, so I also added public methods to get those most-updates settings

## Test Plan and Usage Guide

```
endpoint = client.create_model_endpoint(model_bundle=bundle, **endpoint_params)
# endpoint = client.get_model_endpoint(endpoint.model_endpoint.name)
status = endpoint.status()

while status != "READY":
#     endpoint = client.get_model_endpoint(endpoint.model_endpoint.name)
    status = endpoint.status()
    time.sleep(10)
    
client.delete_model_endpoint(endpoint.model_endpoint)
```
Previously I need to run the 2 commented lines to see the status change from `UPDATE_PENDING` to `READY`, now these 2 lines are no longer needed.

`endpoint.resource_settings()` and `endpoint.worker_settings()` also work

## Clubhouse Ticket

[[ch515389]](https://app.shortcut.com/scaleai/story/515389/modelendpoint-status-is-not-implemented-on-the-client)

## Checklist

If you are deploying a **new service**, please look at the [Production checklist](https://scale.atlassian.net/wiki/spaces/EPD/pages/53903403/Production+checklist)
page. Note that many of these action items must be done well before creating this PR!

General checklist:
- [ ] Make sure you thank your senpai today.
- [ ] Drink 8 cups of water.

_Are you a reviewer? Check out the [Code Review Guide](https://scale.atlassian.net/wiki/spaces/EPD/pages/21921958/Code+Review+Guide)_
