### PR TITLE
Loosen PyYAML constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Please install the pre-commit hooks by running the following command:
 poetry run pre-commit install
 ```
 
+The tests can be run with:
+
+```bash
+poetry run pytest
+```
+
 ### Documentation
 
 **Updating documentation:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [tool.poetry]
 name = "scale-launch"
-version = "0.3.0"
+version = "0.3.1"
 description = "The official Python client library for Launch, the Data Platform for AI"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
@@ -41,7 +41,7 @@ requests = "^2.25.1"
 dataclasses-json = "^0.5.7"
 rich = "^12.0.0"
 deprecation = "^2.1.0"
-pyyaml = "^5.3.1"
+pyyaml = ">=5.3.1,<7.0.0"
 typing-extensions = "^4.1.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
`pyyaml==6.0` was released in October 2021 and is the latest version. There are no incompatibilities with it.

On a side note, all the other launch dependencies look up to date!