### PR TITLE
Add docstring for storage in create_model_endpoint

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -562,6 +562,9 @@ class LaunchClient:
             memory: Amount of memory each worker should get, e.g. "4Gi", "512Mi", etc. This must be a positive
                 amount of memory.
 
+            storage: Amount of local ephemeral storage each worker should get, e.g. "4Gi", "512Mi", etc. This must
+                be a positive amount of storage.
+
             gpus: Number of gpus each worker should get, e.g. 0, 1, etc.
 
             min_workers: The minimum number of workers. Must be greater than or equal to 0. This should be determined


### PR DESCRIPTION
The `storage` option was added to `create_model_endpoint` and `edit_model_endpoint`, but only the docstring for `edit_model_endpoint` modified to include this previously.

Added a description for the storage parameter in the docstring for `create_model_endpoint`.