### PR TITLE
Documentation for model bundles v2

### DIFF
--- a/docs/concepts/model_bundles.md
+++ b/docs/concepts/model_bundles.md
@@ -5,16 +5,45 @@ are created by packaging a model up into a deployable format.
 
 ## Creating Model Bundles
 
-There are two methods for creating model bundles:
-[`create_model_bundle`](/api/client/#launch.client.LaunchClient.create_model_bundle)
+There are three methods for creating model bundles:
+[`create_model_bundle_from_callable_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_callable_v2)
 and
-[`create_model_bundle_from_dirs`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_dirs).
-The former directly pickles a user-specified `load_predict_fn`, a function which
+[`create_model_bundle_from_dirs_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_dirs_v2).
+[`create_model_bundle_from_runnable_image_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_runnable_image_v2).
+The first directly pickles a user-specified `load_predict_fn`, a function which
 loads the model and returns a `predict_fn`, a function which takes in a request.
-The latter takes in directories containing a `load_predict_fn` and the
+The second takes in directories containing a `load_predict_fn` and the
 module path to the `load_predict_fn`.
+The third takes a Docker image that contains an entrypoint that starts a process
+listening for requests at port 5005 using HTTP and exposes `POST /predict` and
+`GET /healthz` endpoints.
 
-=== "Creating a Model Bundle Directly"
+Each of these modes of creating a model bundle is called a "Flavor".
+
+!!! info
+    # Choosing the right model bundle flavor
+
+    Here are some tips for how to choose between the different flavors of ModelBundle:
+
+    A `CloudpickleArtifactFlavor` (creating from callable) is good if:
+
+    * You are creating the model bundle from a Jupyter notebook.
+    * The model bundle is small without too many dependencies.
+
+    A `ZipArtifactFlavor` (creating from directories) is good if:
+
+    * You have a relatively constant set of dependencies.
+    * You have a lot of custom code that you want to include in the model bundle.
+    * You do not want to build a web server and Docker image to serve your model.
+
+    A `RunnableImageArtifactFlavor` (creating from runnable image) is good if:
+
+    * You have a lot of dependencies.
+    * You have a lot of custom code that you want to include in the model bundle.
+    * You are comfortable with building a web server and Docker image to serve your model.
+
+
+=== "Creating From Callables"
     ```py
     import os
     from pydantic import BaseModel
@@ -38,29 +67,27 @@ module path to the `load_predict_fn`.
         return returns_model_of_x_plus_len_of_y
 
 
-    def my_model(x):
-        return x * 2
+    def my_load_model_fn():
+        def my_model(x):
+            return x * 2
 
-    ENV_PARAMS = {
-        "framework_type": "pytorch",
-        "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
-    }
+        return my_model
 
     BUNDLE_PARAMS = {
         "model_bundle_name": "test-bundle",
-        "model": my_model,
+        "load_model_fn": my_load_model_fn,
         "load_predict_fn": my_load_predict_fn,
-        "env_params": ENV_PARAMS,
-        "requirements": ["pytest==7.2.1", "numpy"],  # list your requirements here
         "request_schema": MyRequestSchema,
         "response_schema": MyResponseSchema,
+        "requirements": ["pytest==7.2.1", "numpy"],  # list your requirements here
+        "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     }
 
     client = LaunchClient(api_key=os.getenv("LAUNCH_API_KEY"))
-    client.create_model_bundle(**BUNDLE_PARAMS)
+    client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS)
     ```
 
-=== "Creating a Model Bundle from Directories"
+=== "Creating From Directories"
     ```py
     import os
     import tempfile
@@ -114,30 +141,72 @@ module path to the `load_predict_fn`.
     class MyResponseSchema(BaseModel):
         __root__: int
      
-    ENV_PARAMS = {
-        "framework_type": "pytorch",
-        "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
-    }
-
     BUNDLE_PARAMS = {
         "model_bundle_name": "test-bundle",
         "base_paths": [directory],
-        "requirements_path": "requirements.txt",
-        "env_params": ENV_PARAMS,
-        "load_predict_fn": "predict.my_load_predict_fn",
+        "load_predict_fn_module_path": "predict.my_load_predict_fn",
         "load_model_fn_module_path": "model.my_load_model_fn",
         "request_schema": MyRequestSchema,
         "response_schema": MyResponseSchema,
+        "requirements_path": "requirements.txt",
+        "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     }
 
     client = LaunchClient(api_key=os.getenv("LAUNCH_API_KEY"))
-    client.create_model_bundle_from_dirs(**BUNDLE_PARAMS)
+    client.create_model_bundle_from_dirs_v2(**BUNDLE_PARAMS)
 
     # Clean up files from demo
     os.remove(model_filename)
     os.remove(predict_filename)
     os.rmdir(directory)
     ```
+
+=== "Creating From a Runnable Image"
+    ```py
+    import os
+    from pydantic import BaseModel
+    from launch import LaunchClient
+
+
+    class MyRequestSchema(BaseModel):
+        x: int
+        y: str
+
+    class MyResponseSchema(BaseModel):
+        __root__: int
+
+
+    BUNDLE_PARAMS = {
+        "model_bundle_name": "test-bundle",
+        "load_model_fn": my_load_model_fn,
+        "load_predict_fn": my_load_predict_fn,
+        "request_schema": MyRequestSchema,
+        "response_schema": MyResponseSchema,
+        "repository": "launch_rearch",
+        "tag": "12b9131c5a1489c76592cddd186962cce965f0f6-cpu",
+        "command": [
+            "dumb-init",
+            "--",
+            "ddtrace-run",
+            "run-service",
+            "--config",
+            "/install/launch_rearch/config/service--user_defined_code.yaml",
+            "--concurrency",
+            "1",
+            "--http",
+            "production",
+            "--port",
+            "5005",
+        ],
+        "env": {
+            "TEST_KEY": "test_value",
+        },
+    }
+
+    client = LaunchClient(api_key=os.getenv("LAUNCH_API_KEY"))
+    client.create_model_bundle_from_runnable_image_v2(**BUNDLE_PARAMS)
+    ```
+
 
 ## Configuring Model Bundles
 
@@ -200,35 +269,30 @@ def my_load_model_fn(app_config):
     return my_model_batched
 
 
-ENV_PARAMS = {
-    "framework_type": "pytorch",
-    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
-}
-
 BUNDLE_PARAMS_SINGLE = {
     "model_bundle_name": "test-bundle-single",
     "load_predict_fn": my_load_predict_fn,
     "load_model_fn": my_load_model_fn,
-    "env_params": ENV_PARAMS,
     "requirements": ["pytest==7.2.1", "numpy"],
     "request_schema": MyRequestSchema,
     "response_schema": MyResponseSchema,
+    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     "app_config": {"mode": "single"},
 }
 BUNDLE_PARAMS_BATCHED = {
     "model_bundle_name": "test-bundle-batched",
     "load_predict_fn": my_load_predict_fn,
     "load_model_fn": my_load_model_fn,
-    "env_params": ENV_PARAMS,
     "requirements": ["pytest==7.2.1", "numpy"],
     "request_schema": MyRequestSchema,
     "response_schema": MyResponseSchema,
+    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     "app_config": {"mode": "batched"},
 }
 
 client = LaunchClient(api_key=os.getenv("LAUNCH_API_KEY"))
-bundle_single = client.create_model_bundle(**BUNDLE_PARAMS_SINGLE)
-bundle_batch = client.create_model_bundle(**BUNDLE_PARAMS_BATCHED)
+bundle_single = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_SINGLE)
+bundle_batch = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_BATCHED)
 ```
 
 ## Updating Model Bundles
@@ -236,9 +300,9 @@ bundle_batch = client.create_model_bundle(**BUNDLE_PARAMS_BATCHED)
 Model Bundles are immutable, meaning they cannot be edited once created.
 However, it is possible to clone an existing model bundle with a new `app_config`
 using
-[`clone_model_bundle_with_changes`](/api/client/#launch.client.LaunchClient.clone_model_bundle_with_changes).
+[`clone_model_bundle_with_changes_v2`](/api/client/#launch.client.LaunchClient.clone_model_bundle_with_changes_v2).
 
 ## Listing Model Bundles
 
 To list all the model bundles you own, use
-[`list_model_bundles`](/api/client/#launch.client.LaunchClient.list_model_bundles).
+[`list_model_bundles_v2`](/api/client/#launch.client.LaunchClient.list_model_bundles_v2).

--- a/docs/concepts/model_bundles.md
+++ b/docs/concepts/model_bundles.md
@@ -6,9 +6,9 @@ are created by packaging a model up into a deployable format.
 ## Creating Model Bundles
 
 There are three methods for creating model bundles:
-[`create_model_bundle_from_callable_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_callable_v2)
+[`create_model_bundle_from_callable_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_callable_v2),
+[`create_model_bundle_from_dirs_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_dirs_v2),
 and
-[`create_model_bundle_from_dirs_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_dirs_v2).
 [`create_model_bundle_from_runnable_image_v2`](/api/client/#launch.client.LaunchClient.create_model_bundle_from_runnable_image_v2).
 The first directly pickles a user-specified `load_predict_fn`, a function which
 loads the model and returns a `predict_fn`, a function which takes in a request.

--- a/docs/concepts/model_bundles.md
+++ b/docs/concepts/model_bundles.md
@@ -14,8 +14,8 @@ The first directly pickles a user-specified `load_predict_fn`, a function which
 loads the model and returns a `predict_fn`, a function which takes in a request.
 The second takes in directories containing a `load_predict_fn` and the
 module path to the `load_predict_fn`.
-The third takes a Docker image that contains an entrypoint that starts a process
-listening for requests at port 5005 using HTTP and exposes `POST /predict` and
+The third takes a Docker image and a command that starts a process listening for
+requests at port 5005 using HTTP and exposes `POST /predict` and
 `GET /healthz` endpoints.
 
 Each of these modes of creating a model bundle is called a "Flavor".
@@ -36,7 +36,7 @@ Each of these modes of creating a model bundle is called a "Flavor".
     * You have a lot of custom code that you want to include in the model bundle.
     * You do not want to build a web server and Docker image to serve your model.
 
-    A `RunnableImageArtifactFlavor` (creating from runnable image) is good if:
+    A `RunnableImageFlavor` (creating from runnable image) is good if:
 
     * You have a lot of dependencies.
     * You have a lot of custom code that you want to include in the model bundle.

--- a/launch/client.py
+++ b/launch/client.py
@@ -453,7 +453,7 @@ class LaunchClient:
         load_model_fn_module_path: str,
         request_schema: Type[BaseModel],
         response_schema: Type[BaseModel],
-        requirements_path: str,
+        requirements_path: Optional[str] = None,
         pytorch_image_tag: Optional[str] = None,
         tensorflow_version: Optional[str] = None,
         custom_base_image_repository: Optional[str] = None,
@@ -544,8 +544,10 @@ class LaunchClient:
 
                 - ``model_bundle_id``: The ID of the created model bundle.
         """
-        with open(requirements_path, "r", encoding="utf-8") as req_f:
-            requirements = req_f.read().splitlines()
+        requirements = []
+        if requirements_path is not None:
+            with open(requirements_path, "r", encoding="utf-8") as req_f:
+                requirements = req_f.read().splitlines()
         bundle_location = self._get_bundle_url_from_base_paths(base_paths)
         schema_location = self._upload_schemas(request_schema=request_schema, response_schema=response_schema)
         framework = _get_model_bundle_framework(


### PR DESCRIPTION
Documentation is now live at https://scaleapi.github.io/launch-python-client/concepts/model_bundles/

[[sc-707019]](https://app.shortcut.com/scaleai/story/707019)