### PR TITLE
bump version from 1.0.0 to 1.1.0, we've added the new batch job stuff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = [
 
 [tool.poetry]
 name = "scale-launch"
-version = "1.0.0"
+version = "1.1.0"
 description = "The official Python client library for Launch, the Data Platform for AI"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"


### PR DESCRIPTION
I think we should do this?
note: this corresponds to version 1.1.1 on the autogen client, as far as I can tell version 1.0.0 corresponds to version 1.1.0 on autogen