### PR TITLE
Add timeout to batch job definitions

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -1947,6 +1947,7 @@ class LaunchClient:
         storage: Optional[str] = None,
         max_workers: Optional[int] = None,
         per_worker: Optional[int] = None,
+        timeout_seconds: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Sends a batch inference request using a given bundle. Returns a key that can be used to
@@ -2002,6 +2003,9 @@ class LaunchClient:
                 - ``nvidia-tesla-t4``
                 - ``nvidia-ampere-a10``
 
+            timeout_seconds: The maximum amount of time (in seconds) that the batch job can take.
+                If not specified, the server defaults to 12 hours.
+
         Returns:
             A dictionary that contains `job_id` as a key, and the ID as the value.
         """
@@ -2049,6 +2053,7 @@ class LaunchClient:
             serialization_format=serialization_format,
             labels=labels,
             resource_requests=resource_requests,
+            timeout_seconds=timeout_seconds,
         )
         request = CreateBatchJobV1Request(**payload)
         with ApiClient(self.configuration) as api_client:

--- a/launch/client.py
+++ b/launch/client.py
@@ -2004,7 +2004,8 @@ class LaunchClient:
                 - ``nvidia-ampere-a10``
 
             timeout_seconds: The maximum amount of time (in seconds) that the batch job can take.
-                If not specified, the server defaults to 12 hours.
+                If not specified, the server defaults to 12 hours. This includes the time required
+                to build the endpoint and the total time required for all the individual tasks.
 
         Returns:
             A dictionary that contains `job_id` as a key, and the ID as the value.


### PR DESCRIPTION
https://app.shortcut.com/scaleai/story/754120/launch-batch-job-v1-users-can-specify-timeouts-for-the-jobs