### PR TITLE
Refactor demo code in "Configuring Model Bundles" so that it actually reuses bundle parameters

### DIFF
--- a/docs/concepts/model_bundles.md
+++ b/docs/concepts/model_bundles.md
@@ -309,30 +309,28 @@ def my_load_model_fn(app_config):
     return my_model_batched
 
 
+BUNDLE_PARAMS_BASE = {
+    "load_predict_fn": my_load_predict_fn,
+    "load_model_fn": my_load_model_fn,
+    "requirements": ["pytest==7.2.1", "numpy"],
+    "request_schema": MyRequestSchema,
+    "response_schema": MyResponseSchema,
+    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
+}
+
 BUNDLE_PARAMS_SINGLE = {
     "model_bundle_name": "test-bundle-single",
-    "load_predict_fn": my_load_predict_fn,
-    "load_model_fn": my_load_model_fn,
-    "requirements": ["pytest==7.2.1", "numpy"],
-    "request_schema": MyRequestSchema,
-    "response_schema": MyResponseSchema,
-    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     "app_config": {"mode": "single"},
 }
+
 BUNDLE_PARAMS_BATCHED = {
     "model_bundle_name": "test-bundle-batched",
-    "load_predict_fn": my_load_predict_fn,
-    "load_model_fn": my_load_model_fn,
-    "requirements": ["pytest==7.2.1", "numpy"],
-    "request_schema": MyRequestSchema,
-    "response_schema": MyResponseSchema,
-    "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime",
     "app_config": {"mode": "batched"},
 }
 
 client = LaunchClient(api_key=os.getenv("LAUNCH_API_KEY"))
-bundle_single = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_SINGLE)
-bundle_batch = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_BATCHED)
+bundle_single = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_BASE, **BUNDLE_PARAMS_SINGLE)
+bundle_batch = client.create_model_bundle_from_callable_v2(**BUNDLE_PARAMS_BASE, **BUNDLE_PARAMS_BATCHED)
 ```
 
 ## Updating Model Bundles


### PR DESCRIPTION
# Pull Request Summary

Refactor demo code in "Configuring Model Bundles" so that it actually reuses bundle parameters

## Test Plan and Usage Guide
### Preview from 
```
poetry shell
mkdocs serve
```
<img width="1606" alt="image" src="https://github.com/scaleapi/launch-python-client/assets/134341950/81abd3f6-4dc2-49d4-9481-3b0bb54b5c0a">

### Unit test: 
```
(launch-python-client) 🚫➜  launch-python-client git:(update-Configuring-Model-Bundles-demo-code) poetry run pytest
================================================================= test session starts =================================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/juitse.hung/Desktop/launch-python-client, configfile: pyproject.toml
plugins: mock-3.10.0, requests-mock-1.10.0
collected 20 items                                                                                                                                    

tests/test_client.py::test_create_model_bundle_from_dirs_bundle_contents_correct 
-------------------------------------------------------------------- live log call --------------------------------------------------------------------
INFO     launch.logger:connection.py:70 Make request to https://api.scale.com/v1/hosted_inference/model_bundle_upload
INFO     launch.logger:connection.py:80 API request has response code 200
INFO     launch.client:client.py:984 create_model_bundle_from_dirs: raw_bundle_url=s3://my-fake-bucket/path/to/bundle
PASSED                                                                                                                                          [  5%]
tests/test_client.py::test_get_non_existent_model_endpoint PASSED                                                                               [ 10%]
tests/test_docs.py::test_docs_examples[docs/index.md:10-91] PASSED                                                                              [ 15%]
tests/test_docs.py::test_docs_examples[docs/guides/custom_docker_images.md:28-57] SKIPPED (test='skip' on code snippet)                         [ 20%]
tests/test_docs.py::test_docs_examples[docs/guides/custom_docker_images.md:69-115] SKIPPED (test='skip' on code snippet)                        [ 25%]
tests/test_docs.py::test_docs_examples[docs/concepts/callbacks.md:23-71] PASSED                                                                 [ 30%]
tests/test_docs.py::test_docs_examples[docs/concepts/callbacks.md:89-163] 
-------------------------------------------------------------------- live log call --------------------------------------------------------------------
INFO     launch.client:client.py:1526 Editing existing endpoint
INFO     launch.client:client.py:1593 Endpoint edit task id is <MagicMock name='mock.get()' id='140619063548896'>
PASSED                                                                                                                                          [ 35%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_bundles.md:259-334] PASSED                                                           [ 40%]
tests/test_docs.py::test_docs_examples[docs/concepts/batch_jobs.md:13-43] 
-------------------------------------------------------------------- live log call --------------------------------------------------------------------
INFO     launch.client:client.py:2056 Writing batch task csv to s3://<MagicMock id='140619060276144'>/<MagicMock id='140619060276144'>
INFO     root:batch_jobs_13_43.py:40 the batch job is SUCCESS
INFO     root:batch_jobs_13_43.py:42 {'job_id': 'test-batch-job', 'status': 'SUCCESS'}
PASSED                                                                                                                                          [ 45%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_endpoints.md:41-58] PASSED                                                           [ 50%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_endpoints.md:67-84] PASSED                                                           [ 55%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_endpoints.md:90-96] PASSED                                                           [ 60%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_endpoints.md:98-107] 
-------------------------------------------------------------------- live log call --------------------------------------------------------------------
INFO     launch.client:client.py:1526 Editing existing endpoint
INFO     launch.client:client.py:1593 Endpoint edit task id is <MagicMock name='mock.get()' id='140619063755632'>
PASSED                                                                                                                                          [ 65%]
tests/test_docs.py::test_docs_examples[docs/concepts/model_endpoints.md:109-127] PASSED                                                         [ 70%]
tests/test_import_lib.py::test_dummy PASSED                                                                                                     [ 75%]
tests/test_make_batch_file.py::test_make_batch_file PASSED                                                                                      [ 80%]
tests/test_model_endpoint.py::test_status_returns_updated_value PASSED                                                                          [ 85%]
tests/test_pydantic_schemas.py::test_get_model_definitions PASSED                                                                               [ 90%]
tests/test_pydantic_schemas.py::test_get_model_definitions_from_flat_models PASSED                                                              [ 95%]
tests/test_utils.py::test_trim_kwargs PASSED                                                                                                    [100%]

================================================================== warnings summary ===================================================================
tests/test_client.py::test_create_model_bundle_from_dirs_bundle_contents_correct
  /Users/juitse.hung/Desktop/launch-python-client/tests/test_client.py:71: DeprecatedWarning: create_model_bundle_from_dirs is deprecated as of 1.0.0. Use create_model_bundle_from_dirs_v2.
    client.create_model_bundle_from_dirs(

tests/test_docs.py::test_docs_examples[docs/concepts/batch_jobs.md:13-43]
  /private/var/folders/7z/mq5w4kvj0tnf5km_vkbvwprh0000gq/T/pytest-of-juitse.hung/pytest-1/test_docs_examples_docs_concep3/batch_jobs_13_43.py:37: RuntimeWarning: coroutine 'test_docs_examples.<locals>.dont_sleep' was never awaited
    time.sleep(30)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 18 passed, 2 skipped, 2 warnings in 1.03s ======================================================
(launch-python-client) 🚫➜  launch-python-client git:(update-Configuring-Model-Bundles-demo-code) 
```

## Shortcut Ticket

N/A

