### PR TITLE
add better support for overwriting endpoint

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -95,8 +95,9 @@ from launch.constants import (
     BATCH_TASK_INPUT_SIGNED_URL_PATH,
     ENDPOINT_PATH,
     MODEL_BUNDLE_SIGNED_URL_PATH,
-    SCALE_LAUNCH_ENDPOINT,
-    SCALE_LAUNCH_V1_ENDPOINT,
+    DEFAULT_SCALE_ENDPOINT,
+    HOSTED_INFERENCE_PATH,
+    LAUNCH_PATH,
 )
 from launch.docker_image_batch_job_bundle import (
     CreateDockerImageBatchJobBundleResponse,
@@ -228,15 +229,15 @@ class LaunchClient:
             endpoint: The Scale Launch Endpoint (this should not need to be changed)
             self_hosted: True iff you are connecting to a self-hosted Scale Launch
         """
-        self.connection = Connection(api_key, endpoint or SCALE_LAUNCH_ENDPOINT)
-        self.endpoint = endpoint or SCALE_LAUNCH_V1_ENDPOINT
+        self.endpoint = endpoint or DEFAULT_SCALE_ENDPOINT
+        self.connection = Connection(api_key, self.endpoint + HOSTED_INFERENCE_PATH)
         self.self_hosted = self_hosted
         self.upload_bundle_fn: Optional[Callable[[str, str], None]] = None
         self.upload_batch_csv_fn: Optional[Callable[[str, str], None]] = None
         self.bundle_location_fn: Optional[Callable[[], str]] = None
         self.batch_csv_location_fn: Optional[Callable[[], str]] = None
         self.configuration = Configuration(
-            host=endpoint or SCALE_LAUNCH_V1_ENDPOINT,
+            host=self.endpoint + LAUNCH_PATH,
             discard_unknown_keys=True,
             username=api_key,
             password="",

--- a/launch/client.py
+++ b/launch/client.py
@@ -93,11 +93,11 @@ from launch.api_client.model.zip_artifact_flavor import ZipArtifactFlavor
 from launch.connection import Connection
 from launch.constants import (
     BATCH_TASK_INPUT_SIGNED_URL_PATH,
-    ENDPOINT_PATH,
-    MODEL_BUNDLE_SIGNED_URL_PATH,
     DEFAULT_SCALE_ENDPOINT,
+    ENDPOINT_PATH,
     HOSTED_INFERENCE_PATH,
     LAUNCH_PATH,
+    MODEL_BUNDLE_SIGNED_URL_PATH,
 )
 from launch.docker_image_batch_job_bundle import (
     CreateDockerImageBatchJobBundleResponse,

--- a/launch/client.py
+++ b/launch/client.py
@@ -95,9 +95,9 @@ from launch.constants import (
     BATCH_TASK_INPUT_SIGNED_URL_PATH,
     DEFAULT_SCALE_ENDPOINT,
     ENDPOINT_PATH,
-    HOSTED_INFERENCE_PATH,
-    LAUNCH_PATH,
     MODEL_BUNDLE_SIGNED_URL_PATH,
+    SCALE_LAUNCH_V0_PATH,
+    SCALE_LAUNCH_V1_PATH,
 )
 from launch.docker_image_batch_job_bundle import (
     CreateDockerImageBatchJobBundleResponse,
@@ -230,14 +230,14 @@ class LaunchClient:
             self_hosted: True iff you are connecting to a self-hosted Scale Launch
         """
         self.endpoint = endpoint or DEFAULT_SCALE_ENDPOINT
-        self.connection = Connection(api_key, self.endpoint + HOSTED_INFERENCE_PATH)
+        self.connection = Connection(api_key, self.endpoint + SCALE_LAUNCH_V0_PATH)
         self.self_hosted = self_hosted
         self.upload_bundle_fn: Optional[Callable[[str, str], None]] = None
         self.upload_batch_csv_fn: Optional[Callable[[str, str], None]] = None
         self.bundle_location_fn: Optional[Callable[[], str]] = None
         self.batch_csv_location_fn: Optional[Callable[[], str]] = None
         self.configuration = Configuration(
-            host=self.endpoint + LAUNCH_PATH,
+            host=self.endpoint + SCALE_LAUNCH_V1_PATH,
             discard_unknown_keys=True,
             username=api_key,
             password="",

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -8,7 +8,7 @@ BATCH_TASK_PATH = "batch_job"
 BATCH_TASK_RESULTS_PATH = "batch_job"
 RESULT_PATH = "result"
 DEFAULT_SCALE_ENDPOINT = "https://api.scale.com"
-HOSTED_INFERENCE_PATH = "/v1/hosted_inference"
-LAUNCH_PATH = "/v1/launch"
+SCALE_LAUNCH_V0_PATH = "/v1/hosted_inference"
+SCALE_LAUNCH_V1_PATH = "/v1/launch"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120

--- a/launch/constants.py
+++ b/launch/constants.py
@@ -7,7 +7,8 @@ SYNC_TASK_PATH = "task_sync"
 BATCH_TASK_PATH = "batch_job"
 BATCH_TASK_RESULTS_PATH = "batch_job"
 RESULT_PATH = "result"
-SCALE_LAUNCH_ENDPOINT = "https://api.scale.com/v1/hosted_inference"
-SCALE_LAUNCH_V1_ENDPOINT = "https://api.scale.com/v1/launch"
+DEFAULT_SCALE_ENDPOINT = "https://api.scale.com"
+HOSTED_INFERENCE_PATH = "/v1/hosted_inference"
+LAUNCH_PATH = "/v1/launch"
 
 DEFAULT_NETWORK_TIMEOUT_SEC = 120


### PR DESCRIPTION
Feeding in your own endpoint to the Launch client didn't work very well because some of the calls go to `/v1/hosted_inference` and other calls go to `/v1/launch` and the old behavior rewrote both