### PR TITLE
Don't go up to pydantic 2 because we haven't tested it yet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ python-dateutil = "^2.8.2"
 pyyaml = ">=5.3.1,<7.0.0"
 typing-extensions = "^4.1.1"
 frozendict = "^2.3.4"
-pydantic = ">=1.8.2"
+pydantic = "^1.8.2"
 types-frozendict = "^2.0.9"
 questionary = "^1.10.0"
 click = ">=7.1.2"  # type:


### PR DESCRIPTION
Ran into this when helping @rkaplan - a fresh install with the >= brings in pydantic 2.x, which doesn't work for us right now.