### PR TITLE
Set default stroage to 16Gi in create_model_endpoint

### DIFF
--- a/launch/client.py
+++ b/launch/client.py
@@ -1386,7 +1386,7 @@ class LaunchClient:
         model_bundle: Union[ModelBundle, str],
         cpus: int = 3,
         memory: str = "8Gi",
-        storage: Optional[str] = None,
+        storage: str = "16Gi",
         gpus: int = 0,
         min_workers: int = 1,
         max_workers: int = 1,


### PR DESCRIPTION
Set default storage to 16Gi in create_model_endpoint. Otherwise some endpoints are getting `│  Warning Evicted  32s        kubelet      Pod ephemeral local storage usage exceeds the total limit of containers 1G.` as we previously have storage default to None