### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/launch/__init__.py
+++ b/launch/__init__.py
@@ -8,9 +8,9 @@ into a production service that automatically scales according to traffic.
 # pylint: disable=C0413
 
 import warnings
+from importlib.metadata import version
 from typing import Sequence
 
-import pkg_resources
 import pydantic
 
 if pydantic.VERSION.startswith("2."):
@@ -32,7 +32,7 @@ from .model_endpoint import (
     SyncEndpoint,
 )
 
-__version__ = pkg_resources.get_distribution("scale-launch").version
+__version__ = version("scale-launch")
 __all__: Sequence[str] = [
     "AsyncEndpoint",
     "AsyncEndpointBatchResponse",

--- a/launch/errors.py
+++ b/launch/errors.py
@@ -1,6 +1,6 @@
-import pkg_resources
+from importlib.metadata import version
 
-api_client_version = pkg_resources.get_distribution("scale-launch").version
+api_client_version = version("scale-launch")
 
 INFRA_FLAKE_MESSAGES = [
     "downstream duration timeout",

--- a/launch/find_packages.py
+++ b/launch/find_packages.py
@@ -18,11 +18,18 @@ import ast
 import logging
 import os
 import pkgutil
+import re
 import sys
 import types
 import zipfile
 import zipimport
 from typing import Dict
+
+
+def _canonicalize_name(name: str) -> str:
+    """PEP 503 name normalization, matching the keys pkg_resources used to produce."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
 
 EPP_NO_ERROR = 0
 EPP_PKG_NOT_EXIST = 1
@@ -106,27 +113,7 @@ class ModuleManager:
         self.setuptools_module_set = set()
         self.nonlocal_package_path = set()
 
-        import pkg_resources
-
-        # yixu: this populates either self.pip_pkg_map or self.nonlocal_package_path
-        # pkg_resources.working_set is basically a snapshot of sys.path, i.e. the packages that
-        # are imported
-        for dist in pkg_resources.working_set:  # pylint: disable=not-an-iterable
-            module_path = dist.module_path or dist.location
-            if not module_path:
-                # Skip if no module path was found for pkg distribution
-                continue
-
-            if os.path.realpath(module_path) != os.getcwd():
-                # add to nonlocal_package path only if it's not current directory
-                self.nonlocal_package_path.add(module_path)
-
-            self.pip_pkg_map[dist._key] = dist._version
-            for mn in dist._get_metadata("top_level.txt"):
-                if dist._key != "setuptools":
-                    self.pip_module_map.setdefault(mn, []).append((dist._key, dist._version))
-                else:
-                    self.setuptools_module_set.add(mn)
+        self._index_installed_distributions()
 
         # yixu: searched_modules is basically just pkgutil.iter_modules
         self.searched_modules = {}
@@ -142,12 +129,62 @@ class ModuleManager:
                 is_local = self.is_local_path(path)
                 self.searched_modules[m.name] = ModuleInfo(m.name, path, is_local, m.ispkg)
 
+    def _index_installed_distributions(self):
+        # yixu: this populates either self.pip_pkg_map or self.nonlocal_package_path
+        # distributions() is basically a snapshot of sys.path, i.e. the packages that
+        # are imported
+        from importlib.metadata import distributions
+
+        for dist in distributions():
+            name = dist.metadata["Name"]
+            if not name:
+                # Skip malformed distributions with no name in their metadata
+                continue
+
+            # pkg_resources keyed distributions by a normalized name; importlib.metadata
+            # reports the raw metadata name, so canonicalize to keep the requirement
+            # names emitted by seek_pip_packages() stable.
+            key = _canonicalize_name(name)
+            if key in self.pip_pkg_map:
+                # distributions() also yields shadowed copies (e.g. a vendored tree later
+                # on sys.path). First one wins, since that is the one that actually gets
+                # imported, which pkg_resources.working_set did implicitly.
+                continue
+
+            # locate_file("") resolves to the directory the distribution was installed
+            # into (the parent of its .dist-info/.egg-info). realpath to match the
+            # normalized paths pkg_resources reported, since is_local_path() compares
+            # these against the entries collected here.
+            module_path = os.path.realpath(str(dist.locate_file("")))
+            if not module_path:
+                # Skip if no module path was found for pkg distribution
+                continue
+
+            if module_path != os.getcwd():
+                # add to nonlocal_package path only if it's not current directory
+                self.nonlocal_package_path.add(module_path)
+
+            self.pip_pkg_map[key] = dist.version
+            self._index_top_level_modules(dist, key)
+
+    def _index_top_level_modules(self, dist, key):
+        for mn in (dist.read_text("top_level.txt") or "").splitlines():
+            if not mn:
+                continue
+            if key != "setuptools":
+                self.pip_module_map.setdefault(mn, []).append((key, dist.version))
+            else:
+                self.setuptools_module_set.add(mn)
+
     def verify_pkg(self, pkg_req):
-        if pkg_req.name not in self.pip_pkg_map:
+        # pip_pkg_map is keyed by canonical name, so normalize the requirement name
+        # too: "jaraco.text", "jaraco_text" and "jaraco-text" all name one package.
+        req_key = _canonicalize_name(pkg_req.name)
+        if req_key not in self.pip_pkg_map:
             # package does not exist in the current python session
             return EPP_PKG_NOT_EXIST
 
-        if self.pip_pkg_map[pkg_req.name] not in pkg_req.specifier:
+        if self.pip_pkg_map[req_key] not in pkg_req.specifier:
             # package version being used in the current python session does not meet
             # the specified package version requirement
             return EPP_PKG_VERSION_MISMATCH

--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -1,0 +1,136 @@
+import os
+
+import pytest
+from packaging.requirements import Requirement
+
+from launch.find_packages import (
+    EPP_NO_ERROR,
+    EPP_PKG_NOT_EXIST,
+    EPP_PKG_VERSION_MISMATCH,
+    ModuleManager,
+)
+
+
+class FakeDistribution:
+    """Stands in for an importlib.metadata.Distribution."""
+
+    def __init__(self, name, version, location, top_level=None):
+        self.metadata = {"Name": name}
+        self.version = version
+        self._location = location
+        self._top_level = top_level
+
+    def locate_file(self, path):
+        return os.path.join(self._location, path)
+
+    def read_text(self, filename):
+        return self._top_level if filename == "top_level.txt" else None
+
+
+@pytest.fixture
+def index_distributions(mocker):
+    """Build a ModuleManager over a fixed set of distributions."""
+
+    def _index(dists):
+        mocker.patch("importlib.metadata.distributions", return_value=iter(dists))
+        return ModuleManager()
+
+    return _index
+
+
+def test_distribution_names_are_canonicalized(index_distributions, tmp_path):
+    # importlib.metadata reports the raw Name field, so "Typing_Extensions" and
+    # "jaraco.text" have to be normalized to the names requirements refer to.
+    manager = index_distributions(
+        [
+            FakeDistribution("Typing_Extensions", "4.16.0", str(tmp_path), "typing_extensions\n"),
+            FakeDistribution("jaraco.text", "4.0.0", str(tmp_path), "jaraco\n"),
+        ]
+    )
+
+    assert manager.pip_pkg_map == {"typing-extensions": "4.16.0", "jaraco-text": "4.0.0"}
+    assert manager.pip_module_map["typing_extensions"] == [("typing-extensions", "4.16.0")]
+
+
+def test_verify_pkg_matches_alternate_name_spellings(index_distributions, tmp_path):
+    manager = index_distributions(
+        [FakeDistribution("typing_extensions", "4.16.0", str(tmp_path), "typing_extensions\n")]
+    )
+
+    assert manager.verify_pkg(Requirement("typing-extensions>=4.0")) == EPP_NO_ERROR
+    assert manager.verify_pkg(Requirement("Typing_Extensions>=4.0")) == EPP_NO_ERROR
+    assert manager.verify_pkg(Requirement("typing.extensions>=4.0")) == EPP_NO_ERROR
+    assert manager.verify_pkg(Requirement("typing-extensions<4.0")) == EPP_PKG_VERSION_MISMATCH
+    assert manager.verify_pkg(Requirement("not-installed>=1.0")) == EPP_PKG_NOT_EXIST
+
+
+def test_first_distribution_on_sys_path_wins(index_distributions, tmp_path):
+    # distributions() also yields shadowed copies, e.g. a vendored tree later on
+    # sys.path. The earlier one is the one that actually gets imported.
+    installed = tmp_path / "site-packages"
+    installed.mkdir()
+    vendored = tmp_path / "vendored"
+    vendored.mkdir()
+
+    manager = index_distributions(
+        [
+            FakeDistribution("packaging", "26.3", str(installed), "packaging\n"),
+            FakeDistribution("packaging", "26.0", str(vendored), "packaging\n"),
+        ]
+    )
+
+    assert manager.pip_pkg_map["packaging"] == "26.3"
+    assert manager.pip_module_map["packaging"] == [("packaging", "26.3")]
+    assert str(vendored) not in manager.nonlocal_package_path
+
+
+def test_distribution_paths_are_realpath_normalized(index_distributions, tmp_path):
+    # is_local_path() compares these paths by identity, so an unresolved symlink
+    # would stop a nonlocal package from being recognized as one.
+    installed = tmp_path / "real-site-packages"
+    installed.mkdir()
+    symlinked = tmp_path / "linked-site-packages"
+    symlinked.symlink_to(installed)
+
+    manager = index_distributions([FakeDistribution("some-pkg", "1.0.0", str(symlinked), "some_pkg\n")])
+
+    assert os.path.realpath(str(installed)) in manager.nonlocal_package_path
+    assert str(symlinked) not in manager.nonlocal_package_path
+
+
+def test_distributions_without_a_name_are_skipped(index_distributions, tmp_path):
+    manager = index_distributions(
+        [
+            FakeDistribution(None, "1.0.0", str(tmp_path), "broken\n"),
+            FakeDistribution("good-pkg", "2.0.0", str(tmp_path), "good_pkg\n"),
+        ]
+    )
+
+    assert manager.pip_pkg_map == {"good-pkg": "2.0.0"}
+    assert "broken" not in manager.pip_module_map
+
+
+def test_missing_or_blank_top_level_metadata_is_tolerated(index_distributions, tmp_path):
+    # Wheels are not required to ship top_level.txt, and the ones that do may end
+    # with a trailing newline.
+    manager = index_distributions(
+        [
+            FakeDistribution("no-top-level", "1.0.0", str(tmp_path), None),
+            FakeDistribution("blank-lines", "2.0.0", str(tmp_path), "blank_lines\n\n"),
+        ]
+    )
+
+    assert manager.pip_pkg_map == {"no-top-level": "1.0.0", "blank-lines": "2.0.0"}
+    assert manager.pip_module_map == {"blank_lines": [("blank-lines", "2.0.0")]}
+
+
+def test_setuptools_modules_are_tracked_separately(index_distributions, tmp_path):
+    manager = index_distributions(
+        [
+            FakeDistribution("setuptools", "80.10.2", str(tmp_path), "setuptools\npkg_resources\n"),
+            FakeDistribution("requests", "2.32.0", str(tmp_path), "requests\n"),
+        ]
+    )
+
+    assert manager.setuptools_module_set == {"setuptools", "pkg_resources"}
+    assert manager.pip_module_map == {"requests": [("requests", "2.32.0")]}


### PR DESCRIPTION
## Why

`launch/__init__.py` imports `pkg_resources` at module level. setuptools **82.0.0 removed `pkg_resources`**, and the fix for **CVE-2026-59890** only landed in setuptools **83.0.0**. There is no setuptools version that both carries the CVE fix and still ships `pkg_resources`.

That means every consumer of `scale-launch` is pinned to `setuptools<82` and cannot take the CVE fix. Concretely, `scaleapi/scaleapi`'s `packages/egp-api-backend` carries this in `pyproject.toml`:

```toml
"setuptools>=80.10.1,<81.0",  # runtime: pkg_resources used by transitive deps (e.g. launch).
                              # CVE-2026-59890 fix needs >=83.0.0 but setuptools 82.0.0 removed
                              # pkg_resources, breaking `launch` import at runtime
```

On `setuptools>=82`, `import launch` raises `ModuleNotFoundError: No module named 'pkg_resources'`. This PR removes the dependency so that cap can be lifted.

## What changed

| File | Change |
|---|---|
| `launch/__init__.py` | `__version__` via `importlib.metadata.version("scale-launch")` |
| `launch/errors.py` | `api_client_version` via the same |
| `launch/find_packages.py` | `pkg_resources.working_set` → `importlib.metadata.distributions()` |

`ModuleManager.__init__` was over pylint's branch limit after the rewrite, so the scan moved into `_index_installed_distributions()` / `_index_top_level_modules()`. No signature or public API changes.

## Behavior parity

I diffed the old and new `ModuleManager` in the same interpreter (setuptools 80.10.2 installed, so both code paths work) rather than assuming the two APIs are equivalent. `nonlocal_package_path`, `searched_modules` and `setuptools_module_set` come out **identical**; `pip_pkg_map`/`pip_module_map` are identical except for setuptools' own vendored `jaraco.text` and `backports.tarfile`, now keyed canonically as `jaraco-text` / `backports-tarfile` — and those two vanish entirely once setuptools is uninstalled.

Three genuine API differences needed handling, each of which would otherwise have been a silent regression:

1. **Name derivation.** `pkg_resources` keyed distributions off the `.dist-info` *directory* name; `importlib.metadata` reads the `Name` metadata field. These disagree (`jaraco.text` vs `jaraco-text`), and `pkg_resources` was itself inconsistent — it dashed `jaraco.context` but not `jaraco.text`, purely because of how each dist-info dir happened to be named. Both indexing and the `verify_pkg()` lookup now canonicalize (PEP 503). Side benefit: `verify_pkg()` now matches `Typing_Extensions` against `typing-extensions`, which it previously did not.

2. **Shadowed duplicates.** `distributions()` yields every copy on `sys.path`; `working_set` yielded one. With last-write-wins, setuptools' vendored `packaging` 26.0 overwrote the actually-installed 26.3. First-on-`sys.path` now wins, matching import resolution.

3. **Path normalization.** `pkg_resources`' `location` was realpath-normalized; `locate_file()` is not (`/tmp` vs `/private/tmp` on macOS). `is_local_path()` compares these paths by identity, so the result is now realpath'd.

## Testing

Full suite in a venv with setuptools **completely absent**:

| | result |
|---|---|
| `master` | `ModuleNotFoundError: No module named 'pkg_resources'` — 7 collection errors |
| this branch | **20 passed, 4 skipped** |

Verified on **Python 3.8** (the CI floor per `.circleci/config.yml`) and 3.11. `black`, `ruff`, `isort` clean; `pylint` 10.00/10. The one `mypy` error (`hooks.py:13`, enum annotation) reproduces identically on unmodified `master` and is untouched here.

## Note

`types-setuptools` (dev dep) is now unused. I left it in deliberately — dropping it forces a `poetry.lock` regen, which seemed like unnecessary churn on a security fix. Happy to add it here or follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the setuptools-dependent `pkg_resources` APIs with standard-library `importlib.metadata`.
- Reads the client version through `importlib.metadata.version()`.
- Canonicalizes distribution names and preserves first-on-path handling for duplicate installations.
- Normalizes distribution paths and adds focused package-indexing tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| launch/__init__.py | Replaces the package version lookup with the standard-library metadata API. |
| launch/errors.py | Uses the same standard-library metadata lookup for API error version reporting. |
| launch/find_packages.py | Reimplements installed-distribution indexing with canonical names, normalized paths, and duplicate handling. |
| tests/test_find_packages.py | Adds coverage for canonicalization, duplicate distributions, path normalization, malformed metadata, and setuptools modules. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Flaunch-python-client%20PR%20%23181%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=181&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["Add regression tests for distribution in..."](https://github.com/scaleapi/launch-python-client/commit/5cd17159f0f87c7f5ee4b475d29c36a1fb5b510c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53017391)</sub>

<!-- /greptile_comment -->